### PR TITLE
Fix parameter definition

### DIFF
--- a/helm/scripts/values/values-production.yaml
+++ b/helm/scripts/values/values-production.yaml
@@ -94,7 +94,7 @@ master:
   ## Can be used to disable Redis commands for security reasons.
   ## ref: https://github.com/bitnami/bitnami-docker-redis#disabling-redis-commands
   ##
-  disableCommands: "FLUSHDB,FLUSHALL"
+  disableCommands: ["FLUSHDB,FLUSHALL"]
   ## Enable persistence using Persistent Volume Claims
   ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
   ##


### PR DESCRIPTION
Hello !
There is a new definition of for array parameters. This fixes it.

This was triggering a render error : 
```
$ helm install stable/redis \
    --values values/values-production.yaml \
    --name redis-system
Error: render error in "redis/templates/redis-slave-deployment.yaml": template: redis/templates/redis-slave-deployment.yaml:36:31: executing "redis/templates/redis-slave-deployment.yaml" at <include (print $.Tem...>: error calling include: template: redis/templates/configmap.yaml:19:17: executing "redis/templates/configmap.yaml" at <.Values.master.disab...>: range can't iterate over FLUSHDB,FLUSHALL
```

This will fix #2 